### PR TITLE
Turn off colors when not printing to a tty

### DIFF
--- a/radon/cli.py
+++ b/radon/cli.py
@@ -24,6 +24,9 @@ from radon.complexity import cc_visit, cc_rank, sorted_results
 from radon.raw import analyze
 from radon.metrics import mi_visit, mi_rank
 
+if not sys.stdout.isatty():
+    GREEN = YELLOW = RED = MAGENTA = CYAN = WHITE = BRIGHT = RESET = ''
+
 
 RANKS_COLORS = {'A': GREEN, 'B': GREEN,
                 'C': YELLOW, 'D': YELLOW,


### PR DESCRIPTION
This is a pretty quick hack that disables the colors when printing to a file or piping through another program. It might also be useful to manually control this with something like `--no-colors`.
