### PR TITLE
Add preliminary explanation of block types to the cc documentation.

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -33,6 +33,18 @@ Ranks corresponds to complexity scores as follows:
        41+      F      very high - error-prone, unstable block
     ========== ====== =========================================
 
+Blocks are also classified into three types: functions, methods and classes.
+They're listed by letter in the command output for convenience when scanning
+through a longer list of blocks:
+
+    ============ ========
+     Block type   Letter
+    ============ ========
+     Function     F
+     Method       M
+     Class        C
+    ============ ========
+
 Options
 +++++++
 


### PR DESCRIPTION
I've been using this tool for a couple days now, and it's pretty fantastic (never been good at eyeballing complexity, so something that gives me a rough idea of when and where my code's at risk of getting snarly is a big win), but it was really bothering me that there was no obvious explanation outside of the code for what the F, M, and C in the `radon cc` output were (it's certainly possible to guess, but a guess is only useful for learning if you can prove or disprove that it's right).

So I've started tweaking that section of the docs, in the hope that there'll be a nice obvious place to see it explained. This is pretty much the bare minimum that I feel actually gets across what they are, but I think it could still do with some work, if only to make it better fit the style of the rest of the docs.

Anyway, hope this helps, and keep up the good work. :)
