### PR TITLE
Fix for --exclude option not working in py3

### DIFF
--- a/radon/cli.py
+++ b/radon/cli.py
@@ -68,7 +68,7 @@ def walk_paths(paths):
 
 
 def iter_filenames(paths, exclude):
-    exclude = filter(None, (exclude or '').split(','))
+    exclude = list(filter(None, (exclude or '').split(',')))
     for path in walk_paths(paths):
         if all(not fnmatch.fnmatch(path, pattern) for pattern in exclude):
             yield path

--- a/radon/tests/test_cli.py
+++ b/radon/tests/test_cli.py
@@ -1,5 +1,7 @@
 import os.path
-from radon.cli import cc, mi, raw
+import tempfile
+import shutil
+from radon.cli import cc, mi, raw, iter_filenames
 from paramunittest import *
 
 
@@ -14,3 +16,51 @@ class TestGeneralCommands(ParametrizedTestCase):
 
     def testItWorks(self):
         self.assertTrue(self.command(RADON_DIR) is None)
+
+    def testIterFilenames(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            os.makedirs(os.path.join(tmpdir, 'd1'))
+            f1 = os.path.join(tmpdir, 'd1', 't1.py')
+            open(f1, 'w').close()
+            f2 = os.path.join(tmpdir, 'd1', 't2.py')
+            open(f2, 'w').close()
+            os.makedirs(os.path.join(tmpdir, 'd2'))
+            f3 = os.path.join(tmpdir, 'd2', 't3.py')
+            open(f3, 'w').close()
+            f4 = os.path.join(tmpdir, 'd2', 't4.py')
+            open(f4, 'w').close()
+
+            dir1 = [os.path.join(tmpdir, 'd1')]
+            dir12 = [os.path.join(tmpdir, 'd1'), os.path.join(tmpdir, 'd2')]
+            dirall = [tmpdir]
+
+            # Test without excludes
+            exclude = ''
+            names = iter_filenames(dirall, exclude)
+            self.assertEqual(set(names), set([f1, f2, f3, f4]))
+            names = iter_filenames(dir12, exclude)
+            self.assertEqual(set(names), set([f1, f2, f3, f4]))
+            names = iter_filenames(dir1, exclude)
+            self.assertEqual(set(names), set([f1, f2]))
+
+            # Test with one exclude
+            exclude = '*/t2.py'
+            names = iter_filenames(dirall, exclude)
+            self.assertEqual(set(names), set([f1, f3, f4]))
+            names = iter_filenames(dir12, exclude)
+            self.assertEqual(set(names), set([f1, f3, f4]))
+            names = iter_filenames(dir1, exclude)
+            self.assertEqual(set(names), set([f1]))
+
+            # Test with two excludes
+            exclude = '*/t2.py,*/d2/*'
+            names = iter_filenames(dirall, exclude)
+            self.assertEqual(set(names), set([f1]))
+            names = iter_filenames(dir12, exclude)
+            self.assertEqual(set(names), set([f1]))
+            names = iter_filenames(dir1, exclude)
+            self.assertEqual(set(names), set([f1]))
+        finally:
+            shutil.rmtree(tmpdir)
+


### PR DESCRIPTION
Method iter_filenames uses filter(), which returns an iterable in python3.
This iterable is consumed at the first item yielded by walk_paths,
'exclude' being empty for all paths after that.
