### PR TITLE
Add support to read code from stdin

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -119,6 +119,11 @@ matching ``path/tests/*`` and ``path/docs/*``.
 .. warning::
     Remember to quote the patterns, otherwise your shell might expand them!
 
+::
+
+    $ cat path/to/file.py | radon cc -
+
+Setting the path to "-" will cause Radon to analyze code from stdin
 
 ::
 

--- a/radon/tools.py
+++ b/radon/tools.py
@@ -11,7 +11,10 @@ from radon.complexity import cc_rank
 def iter_filenames(paths, exclude=None, ignore=None):
     '''A generator that yields all sub-paths of the ones specified in `paths`.
     Optional exclude filters can be passed as a comma-separated string of
-    fnmatch patterns.'''
+    fnmatch patterns.
+    If paths contains only a single hyphen, stdin is implied, return as is.'''
+    if set(paths) == set(('-',)):
+        return paths
     finder = lambda path: build_finder(path, build_filter(exclude),
                                        build_ignore(ignore))
     return itertools.chain(*list(map(finder, paths)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,11 @@ class TestGeneralCommands(ParametrizedTestCase):
             self.assertEqual(set(names), set([f1]))
             names = iter_filenames(dir1, exclude)
             self.assertEqual(set(names), set([f1]))
+
+            # Test with "-" is preserved for stdin if it's the only
+            # parameter
+            names = iter_filenames(['-'])
+            self.assertEqual(set(names), set(['-']))
         finally:
             shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
It would be cool to support reading from stdin:

```
cat foo.py | radon cc -
```

This also allows for analyzing specific versions of a file from a repo without having to checkout a local copy first. i.e.

```
git show MY_SHA:path/to/file.py | radon mi -
```
