### PR TITLE
Fix --xml to work with errors

### DIFF
--- a/radon/cli/tools.py
+++ b/radon/cli/tools.py
@@ -106,6 +106,8 @@ def dict_to_xml(results):
     ccm = et.Element('ccm')
     for filename, blocks in results.items():
         for block in blocks:
+            if block == 'error':
+                continue
             metric = et.SubElement(ccm, 'metric')
             complexity = et.SubElement(metric, 'complexity')
             complexity.text = str(block['complexity'])


### PR DESCRIPTION
I hit this issue in my Jenkins build. The strange thing, running radon in the terminal does not reproduce this bug, but in Jenkins block is returned as "error". I see that similar methods from harvest.py filter that value, but not in case with XML.

Perhaps it has something to do with the default encoding change from utf8 to ascii inside Jenkins SSH session. I had many CI bugs because of that anyway.