### PR TITLE
Change lines of code to calculate lines of code instead of lines in file...

### DIFF
--- a/radon/raw.py
+++ b/radon/raw.py
@@ -30,7 +30,8 @@ TOKEN_NUMBER = operator.itemgetter(0)
 #   comments = Comments lines
 #   blank = Blank lines (or whitespace-only lines)
 Module = collections.namedtuple('Module', ['loc', 'lloc', 'sloc',
-                                           'comments', 'multi', 'blank', 'single_comments'])
+                                           'comments', 'multi', 'blank',
+                                           'single_comments'])
 
 
 def _generate(code):
@@ -249,7 +250,9 @@ def remove_python_documentation(doc):
     multi = 1
     for line_count, line in enumerate(doc):
 
-        lines_to_remove, removed = find_comments(lines_to_remove, line_count, line)
+        lines_to_remove, removed = find_comments(lines_to_remove,
+                                                 line_count,
+                                                 line)
         if removed:
             comments += 1
             continue
@@ -290,9 +293,11 @@ def analyze(source):
     interpreter, they are not comments but strings.
     '''
     lloc = comments = multi = blank = 0
-    sloc = len([line.strip() for line in source.split('\n') if line])
-    loc, single_comments, multi = remove_python_documentation([line.strip() for line in source.split('\n')\
-            if line])
+
+    # Cast source code into an array, devoid of blank lines
+    source_array = [line.strip() for line in source.split('\n') if line]
+    sloc = len(source_array)
+    loc, single_comments, multi = remove_python_documentation(source_array)
     lines = iter(source.splitlines())
     for lineno, line in enumerate(lines, 1):
         line = line.strip()
@@ -301,7 +306,7 @@ def analyze(source):
             continue
         try:
             # Process a logical line that spans on multiple lines
-            tokens, sloc_incr, multi_incr = _get_all_tokens(line, lines)
+            tokens, _, _ = _get_all_tokens(line, lines)
         except StopIteration:
             raise SyntaxError('SyntaxError at line: {0}'.format(lineno))
         # Add the comments

--- a/radon/raw.py
+++ b/radon/raw.py
@@ -149,27 +149,24 @@ def _logical(tokens):
 
 
 def remove_lines(doc, lines_to_remove):
+    '''Removes lines from a document.
+    :param doc: [str], document cast into an array.
+    :param lines_to_remove: [int], list of lines to remove from the doc.
+    :return: [str], doc with specified lines removed.
     '''
-    Removes lines from a document.
 
-    @param doc: [str], document cast into an array.
-    @param lines_to_remove: [int], list of lines to remove from the doc.
-    @return: [str], doc with specified lines removed.
-    '''
     for line_number in lines_to_remove:
         doc[line_number] = []
     return [line.strip() for line in doc if line]
 
 
 def is_multiline_string(doc, line_count, quote_type):
-    '''
-    Cases to catch multiline_strings.
-
-    @param doc: [str], a document cast into an array.
-    @param line_count: int, zero based index that points to the current line
+    '''Cases to catch multiline_strings.
+    :param doc: [str], a document cast into an array.
+    :param line_count: int, zero based index that points to the current line
                  in an docuement.
-    @param quote_type: str, one of the two multiline quotes available in python.
-    @return: bool, True if the triple quoted line is a multiline string.
+    :param quote_type: str, one of the two multiline quotes available in python.
+    :return: bool, True if the triple quoted line is a multiline string.
     '''
 
     line = doc[line_count]
@@ -185,16 +182,16 @@ def is_multiline_string(doc, line_count, quote_type):
 
 def find_multiline_comments(lines_to_remove, end, doc, line_count, quote_type):
     '''
-    @param lines_to_remove: [int], a zero based index that represents lines to
+    :param lines_to_remove: [int], a zero based index that represents lines to
                             to be removed from a document.
-    @param end: bool, if True then the first of the two multiline comments has
+    :param end: bool, if True then the first of the two multiline comments has
                 been found.
-    @param doc: [str], a document cast into an array.
-    @param line_count: int, zero based index that points to the current line
+    :param doc: [str], a document cast into an array.
+    :param line_count: int, zero based index that points to the current line
                  in an docuement.
-    @param quote_type: str, one of the two multiline quotes available in python.
-    @return lines_to_remove: same as that passed in, with additions.
-    @return end: bool, updated version of end paramater.
+    :param quote_type: str, one of the two multiline quotes available in python.
+    :return: tuple, lines_to_remove = same as that passed in, with additions.
+                    end = bool, updated version of end paramater.
     '''
 
     # Exceptions: Quote type needs to exist, to get the first line of a
@@ -220,17 +217,15 @@ def find_multiline_comments(lines_to_remove, end, doc, line_count, quote_type):
 
 
 def find_comments(lines_to_remove, line_count, line):
-    '''
-    Find single line comments in a python file.
-
-    @param lines_to_remove: [int], a zero based index that represents lines to
+    '''Find single line comments in a python file.
+    :param lines_to_remove: [int], a zero based index that represents lines to
                             to be removed from a document.
-    @param line_count: int, zero based index that points to the current line
+    :param line_count: int, zero based index that points to the current line
                        in an docuement.
-    @param line: str, the current line in a document being examined.
-    @return lines_to_remove: [int], same as parameter with additional indices
-                             that were found.
+    :param line: str, the current line in a document being examined.
+    :return: [int], same as parameter with additional indices that were found.
     '''
+
     if not line:
         return lines_to_remove
 
@@ -241,11 +236,9 @@ def find_comments(lines_to_remove, line_count, line):
 
 
 def remove_python_documentation(doc):
-    '''
-    Removes all the documentation from python code.
-
-    @param doc: [str], each line of a code recasted as an array
-    @return [str], doc that was passed in, excluding lines of documentation.
+    '''Removes all the documentation from python code.
+    :param doc: [str], each line of a code recasted as an array
+    :return: [str], doc that was passed in, excluding lines of documentation.
     '''
 
     multi_quos = ["'''", '"""']

--- a/radon/tests/run.py
+++ b/radon/tests/run.py
@@ -5,5 +5,5 @@ if __name__ == '__main__':
     except ImportError:
         argv = None
     else:
-        argv = ['nosetests', '--rednose']
+        argv = ['nosetests', '--rednose', '--nocapture', '--pdb']
     nose.main(argv=argv)

--- a/radon/tests/run.py
+++ b/radon/tests/run.py
@@ -5,5 +5,5 @@ if __name__ == '__main__':
     except ImportError:
         argv = None
     else:
-        argv = ['nosetests', '--rednose', '--nocapture', '--pdb']
+        argv = ['nosetests', '--rednose']
     nose.main(argv=argv)

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -160,9 +160,9 @@ CC_TO_XML_CASE = [
 class TestDictConversion(unittest.TestCase):
 
     def test_raw_to_dict(self):
-        self.assertEqual(tools.raw_to_dict(Module(103, 123, 98, 8, 19, 5)),
+        self.assertEqual(tools.raw_to_dict(Module(103, 123, 98, 8, 19, 5, 3)),
                          {'loc': 103, 'lloc': 123, 'sloc': 98, 'comments': 8,
-                          'multi': 19, 'blank': 5})
+                             'multi': 19, 'blank': 5, 'single_comments': 3})
 
     def test_cc_to_xml(self):
         self.assertEqual(tools.dict_to_xml({'filename': CC_TO_XML_CASE}),

--- a/radon/tests/test_raw.py
+++ b/radon/tests/test_raw.py
@@ -141,13 +141,13 @@ class TestLogicalLines(ParametrizedTestCase):
 
 ANALYZE_CASES = [
     ('''
-     ''', (0, 0, 0, 0, 0, 0)),
+     ''', (0, 0, 0, 0, 0, 0, 0)),
 
     ('''
      """
      doc?
      """
-     ''', (0, 1, 3, 0, 3, 0)),
+     ''', (0, 1, 3, 0, 3, 0, 0)),
 
     ('''
      # just a comment
@@ -156,13 +156,13 @@ ANALYZE_CASES = [
      else:
          # you'll never get here
          print('ven')
-     ''', (4, 4, 6, 2, 0, 0)),
+     ''', (4, 4, 6, 2, 0, 0, 2)),
 
     ('''
      #
      #
      #
-     ''', (0, 0, 3, 3, 0, 0)),
+     ''', (0, 0, 3, 3, 0, 0, 3)),
 
     ('''
      if a:
@@ -171,7 +171,7 @@ ANALYZE_CASES = [
 
      else:
          print
-     ''', (4, 4, 4, 0, 0, 2)),
+     ''', (4, 4, 4, 0, 0, 2, 0)),
 
     # In this case the docstring is not counted as a multi-line string
     # because in fact it is on one line!
@@ -179,7 +179,7 @@ ANALYZE_CASES = [
      def f(n):
          """here"""
          return n * f(n - 1)
-     ''', (2, 3, 3, 0, 0, 0)),
+     ''', (2, 3, 3, 0, 0, 0, 1)),
 
     ('''
      def hip(a, k):
@@ -194,7 +194,7 @@ ANALYZE_CASES = [
          """
          if n <= 1: return 1  # otherwise it will melt the cpu
          return fib(n - 2) + fib(n - 1)
-     ''', (12, 9, 11, 2, 4, 1)),
+     ''', (6, 9, 10, 2, 3, 1, 1)),
 
     ('''
      a = [1, 2, 3,
@@ -217,5 +217,5 @@ class TestAnalyze(ParametrizedTestCase):
         else:
             result = analyze(self.code)
             self.assertEqual(result, self.expected)
-            # blank + sloc = loc
-            self.assertTrue(result[0] == result[2] + result[5])
+            # sloc - single_comments - multi  = loc
+            self.assertTrue(result[0] == result[2] - result[6] - result[4])

--- a/radon/tests/test_raw.py
+++ b/radon/tests/test_raw.py
@@ -270,6 +270,18 @@ ANALYZE_CASES = [
         # Comment
     ''', (6, 6, 10, 2, 3, 0, 1)),
 
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        test = 0
+        string =\
+                """
+                This is a string not a comment
+                """
+    ''', (6, 6, 9, 1, 3, 0, 0)),
 ]
 
 

--- a/radon/tests/test_raw.py
+++ b/radon/tests/test_raw.py
@@ -199,6 +199,77 @@ ANALYZE_CASES = [
     ('''
      a = [1, 2, 3,
      ''', SyntaxError),
+
+    # Test that handling of parameters with a value passed in.
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+    ''', (2, 4, 5, 1, 3, 0, 0)),
+
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        string = """This is a string not a comment"""
+    ''', (3, 5, 6, 1, 3, 0, 0)),
+
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        string = """
+                 This is a string not a comment
+                 """
+    ''', (5, 5, 8, 1, 3, 0, 0)),
+
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        string ="""
+                This is a string not a comment
+                """
+        test = 0
+    ''', (6, 6, 9, 1, 3, 0, 0)),
+
+    # Breaking lines still treated as single line of code.
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        string =\
+                """
+                This is a string not a comment
+                """
+        test = 0
+    ''', (6, 6, 9, 1, 3, 0, 0)),
+
+    # Test handling of last line comment.
+    ('''
+     def foo(n=1):
+        """
+        Try it with n = 294942: it will take a fairly long time.
+        """
+        if n <= 1: return 1  # otherwise it will melt the cpu
+        string =\
+                """
+                This is a string not a comment
+                """
+        test = 0
+        # Comment
+    ''', (6, 6, 10, 2, 3, 0, 1)),
+
 ]
 
 

--- a/radon/tests/test_raw.py
+++ b/radon/tests/test_raw.py
@@ -147,7 +147,7 @@ ANALYZE_CASES = [
      """
      doc?
      """
-     ''', (3, 1, 3, 0, 3, 0)),
+     ''', (0, 1, 3, 0, 3, 0)),
 
     ('''
      # just a comment
@@ -156,13 +156,13 @@ ANALYZE_CASES = [
      else:
          # you'll never get here
          print('ven')
-     ''', (6, 4, 6, 2, 0, 0)),
+     ''', (4, 4, 6, 2, 0, 0)),
 
     ('''
      #
      #
      #
-     ''', (3, 0, 3, 3, 0, 0)),
+     ''', (0, 0, 3, 3, 0, 0)),
 
     ('''
      if a:
@@ -171,7 +171,7 @@ ANALYZE_CASES = [
 
      else:
          print
-     ''', (6, 4, 4, 0, 0, 2)),
+     ''', (4, 4, 4, 0, 0, 2)),
 
     # In this case the docstring is not counted as a multi-line string
     # because in fact it is on one line!
@@ -179,7 +179,7 @@ ANALYZE_CASES = [
      def f(n):
          """here"""
          return n * f(n - 1)
-     ''', (3, 3, 3, 0, 0, 0)),
+     ''', (2, 3, 3, 0, 0, 0)),
 
     ('''
      def hip(a, k):


### PR DESCRIPTION
### What's this PR do?
Updates the way lines of code is calculated.  Currently, radon represents lines of code as the total number of lines in a file.  While I believe there are merits for choosing to use lines in file as lines in code, I believe a more accurate measure of the lines of code are all lines in the file that are not blank, docstrings, or comments.  This PR is an attempt to address this issue.

### What's next?
Next will be to update the code and tests if we decide to move forward with the logical change.