### PR TITLE
add docs to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include README.rst
 include requirements.txt
 include tox_requirements.txt
 include tox.ini
+recursive-include docs *
 recursive-include radon/tests *
 global-exclude *.pyc __pycache__


### PR DESCRIPTION
When packaging the sdist, it is sometimes useful to have the
documentation available to install on the system as well.