### PR TITLE
Add support for Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,13 @@
-languages:
-    Python: true
+engines:
+    radon:
+        enabled: true
+        config:
+            threshold: 'B'
+    pep8:
+        enabled: true
+ratings:
+    paths:
+    - "**.py"
 exclude_paths:
-    - "docs/*"
-    - "radon/tests/*"
+- "docs/*"
+- "radon/tests/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.5
+MAINTAINER Rubik
+
+WORKDIR /usr/src/app
+
+COPY tox_requirements.txt /usr/src/app/
+RUN pip install -r tox_requirements.txt
+
+RUN adduser -u 9000 app
+COPY . /usr/src/app
+RUN pip install .
+
+WORKDIR /code
+
+USER app
+
+VOLUME /code
+
+CMD ["/usr/src/app/codeclimate-radon"]

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import json
+import os.path
+
+threshold = "b"
+include_paths = ["."]
+
+if os.path.exists("/config.json"):
+    contents = open("/config.json").read()
+    config = json.loads(contents)
+
+    if config.get("config") and config["config"].get("threshold"):
+        threshold = config["config"]["threshold"].lower()
+
+    if config.get("include_paths"):
+        config_paths = config.get("include_paths")
+        python_paths = []
+        for i in config_paths:
+            ext = os.path.splitext(i)[1]
+            if os.path.isdir(i) or "py" in ext:
+                python_paths.append(i)
+        include_paths = python_paths
+
+if len(include_paths) > 0:
+    args = " ".join(include_paths)
+    os.system("radon cc {0} -n{1} --codeclimate".format(args, threshold))

--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -16,7 +16,7 @@ program = Program(version=sys.modules['radon'].__version__)
 @program.arg('paths', nargs='+')
 def cc(paths, min='A', max='F', show_complexity=False, average=False,
        exclude=None, ignore=None, order='SCORE', json=False, no_assert=False,
-       show_closures=False, total_average=False, xml=False):
+       show_closures=False, total_average=False, xml=False, codeclimate=False):
     '''Analyze the given Python modules and compute Cyclomatic
     Complexity (CC).
 
@@ -43,6 +43,7 @@ def cc(paths, min='A', max='F', show_complexity=False, average=False,
         ALPHA.
     :param -j, --json: Format results in JSON.
     :param --xml: Format results in XML (compatible with CCM).
+    :param --codeclimate: Format results for Code Climate.
     :param --no-assert: Do not count `assert` statements when computing
         complexity.
     :param --show-closures: Add closures to the output.
@@ -60,7 +61,7 @@ def cc(paths, min='A', max='F', show_complexity=False, average=False,
         show_closures=show_closures,
     )
     harvester = CCHarvester(paths, config)
-    log_result(harvester, json=json, xml=xml)
+    log_result(harvester, json=json, xml=xml, codeclimate=codeclimate)
 
 
 @program.command
@@ -170,7 +171,8 @@ def log_result(harvester, **kwargs):
 
     Keywords parameters determine how the results are formatted. If *json* is
     `True`, then `harvester.as_json()` is called. If *xml* is `True`, then
-    `harvester.as_xml()` is called.
+    `harvester.as_xml()` is called. If *codeclimate* is True, then
+    `harvester.as_codeclimate_issues()` is called.
     Otherwise, `harvester.to_terminal()` is executed and `kwargs` is directly
     passed to the :func:`~radon.cli.log` function.
     '''
@@ -178,6 +180,8 @@ def log_result(harvester, **kwargs):
         log(harvester.as_json(), noformat=True)
     elif kwargs.get('xml'):
         log(harvester.as_xml(), noformat=True)
+    elif kwargs.get('codeclimate'):
+        log_list(harvester.as_codeclimate_issues(), delimiter='\0', noformat=True)
     else:
         for msg, args, kwargs in harvester.to_terminal():
             if kwargs.get('error', False):
@@ -198,8 +202,9 @@ def log(msg, *args, **kwargs):
     in any way.
     '''
     indent = 4 * kwargs.get('indent', 0)
+    delimiter = kwargs.get('delimiter', '\n')
     m = msg if kwargs.get('noformat', False) else msg.format(*args)
-    sys.stdout.write(' ' * indent + m + '\n')
+    sys.stdout.write(' ' * indent + m + delimiter)
 
 
 def log_list(lst, *args, **kwargs):

--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -7,7 +7,7 @@ from radon.metrics import mi_visit, mi_rank
 from radon.complexity import cc_visit, sorted_results, cc_rank, add_closures
 from radon.cli.colors import RANKS_COLORS, MI_RANKS, RESET
 from radon.cli.tools import (iter_filenames, _open, cc_to_dict, dict_to_xml,
-                             cc_to_terminal, raw_to_dict)
+                             dict_to_codeclimate_issues, cc_to_terminal, raw_to_dict)
 
 
 class Harvester(object):
@@ -95,6 +95,10 @@ class Harvester(object):
         '''Format the results as XML.'''
         raise NotImplementedError
 
+    def as_codeclimate_issues(self):
+        '''Format the results as Code Climate issues.'''
+        raise NotImplementedError
+
     def to_terminal(self):
         '''Yields tuples representing lines to be printed to a terminal.
 
@@ -136,6 +140,10 @@ class CCHarvester(Harvester):
         Jenkin's CCM plugin. Therefore not all the fields are kept.
         '''
         return dict_to_xml(self._to_dicts())
+
+    def as_codeclimate_issues(self):
+        '''Format the result as Code Climate issues.'''
+        return dict_to_codeclimate_issues(self._to_dicts(), self.config.min)
 
     def to_terminal(self):
         '''Yield lines to be printed in a terminal.'''

--- a/radon/tests/test_cli.py
+++ b/radon/tests/test_cli.py
@@ -68,7 +68,7 @@ class TestCommands(unittest.TestCase):
             min='A', max='F', exclude=None, ignore=None, show_complexity=False,
             average=False, order=getattr(cc_mod, 'SCORE'), no_assert=False,
             total_average=False, show_closures=False))
-        log_mock.assert_called_once_with(mock.sentinel.harvester, json=True,
+        log_mock.assert_called_once_with(mock.sentinel.harvester, codeclimate=False, json=True,
                                          xml=False)
 
     @mock.patch('radon.cli.log_result')

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import unittest
 import radon.cli.tools as tools
 from radon.visitors import Function, Class
@@ -157,6 +158,17 @@ CC_TO_XML_CASE = [
 ]
 
 
+CC_TO_CODECLIMATE_CASE = [
+    {'closures': [], 'endline': 16, 'complexity': 6, 'lineno': 12, 'type':
+     'function', 'name': 'foo', 'col_offset': 0, 'rank': 'B'},
+
+    {'complexity': 8, 'endline': 29, 'rank': 'B', 'lineno': 17, 'type': 'class',
+    'name': 'Classname', 'col_offset': 0},
+
+    {'closures': [], 'endline': 17, 'complexity': 4, 'lineno': 13, 'type':
+     'method', 'name': 'bar', 'col_offset': 4, 'rank': 'A'},
+]
+
 class TestDictConversion(unittest.TestCase):
 
     def test_raw_to_dict(self):
@@ -208,6 +220,39 @@ class TestDictConversion(unittest.TestCase):
                                 <endLineNumber>16</endLineNumber>
                               </metric>
                             </ccm>'''.replace('\n', '').replace(' ', ''))
+
+    def test_cc_to_codeclimate(self):
+        actual_results = tools.dict_to_codeclimate_issues({'filename': CC_TO_CODECLIMATE_CASE})
+        expected_results = [
+                            json.dumps({
+                                "description":"Cyclomatic complexity is too high in function foo. (6)",
+                                "check_name":"Complexity",
+                                "content": { "body": tools.get_content()},
+                                "location": { "path": "filename", "lines": {"begin": 12, "end": 16}},
+                                "type":"issue",
+                                "categories": ["Complexity"],
+                                "remediation_points": 1100000
+                                }),
+                            json.dumps({
+                                "description":"Cyclomatic complexity is too high in class Classname. (8)",
+                                "check_name":"Complexity",
+                                "content": {"body": tools.get_content()},
+                                "location": {"path": "filename", "lines": {"begin": 17, "end": 29}},
+                                "type":"issue",
+                                "categories": ["Complexity"],
+                                "remediation_points": 1300000
+                                }),
+                            ]
+
+        actual_sorted = []
+        for i in actual_results:
+             actual_sorted.append(json.loads(i))
+
+        expected_sorted = []
+        for i in expected_results:
+             expected_sorted.append(json.loads(i))
+
+        self.assertEqual(actual_sorted, expected_sorted)
 
 
 CC_TO_TERMINAL_CASES = [


### PR DESCRIPTION
This PR creates a native Code Climate integration in Radon by
adding:

1) Dockerfile to run Radon as an engine
2) --codeclimate report format
3) `get_content` and `get_remediation_point` methods that provide informational issue content and a measure of the amount of effort needed to repair an engineering problem.