### PR TITLE
Add Python 2 support to Code Climate engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM python:3.5
+FROM python:3.5.1-slim
 MAINTAINER rubik
 
 WORKDIR /usr/src/app
 
+RUN apt-get update && \
+  apt-get install -y python2.7 python-pip && \
+  apt-get clean
+
 COPY tox_requirements.txt /usr/src/app/
-RUN pip install -r tox_requirements.txt
+RUN pip install --quiet --requirement tox_requirements.txt
+RUN pip2 install --quiet --requirement tox_requirements.txt
 
 RUN adduser -u 9000 app
+
 COPY . /usr/src/app
-RUN pip install .
+RUN pip install --quiet . && \
+  mv /usr/local/bin/radon /usr/local/bin/radon3
+RUN pip2 install --quiet . && \
+  mv /usr/local/bin/radon /usr/local/bin/radon2
 
 WORKDIR /code
 

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -35,4 +35,6 @@ if os.path.exists("/config.json"):
 
 if len(include_paths) > 0:
     paths = " ".join(shlex.quote(path) for path in include_paths)
+
+    print("Running {0}...".format(binstub), file = sys.stderr)
     os.system("{0} cc {1} -n{2} --codeclimate".format(binstub, paths, threshold))

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -2,16 +2,26 @@
 
 import json
 import os.path
+import sys
 
 threshold = "b"
+binstub = "radon3"
 include_paths = ["."]
 
 if os.path.exists("/config.json"):
     contents = open("/config.json").read()
     config = json.loads(contents)
 
-    if config.get("config") and config["config"].get("threshold"):
-        threshold = config["config"]["threshold"].lower()
+    if config.get("config"):
+        if config["config"].get("threshold"):
+            threshold = config["config"]["threshold"].lower()
+
+        if config["config"].get("python_version"):
+            version = config["config"].get("python_version")
+            if version == "2":
+                binstub = "radon2"
+            elif version != "3":
+                sys.exit("Invalid python_version; must be either 2 or 3")
 
     if config.get("include_paths"):
         config_paths = config.get("include_paths")
@@ -24,4 +34,4 @@ if os.path.exists("/config.json"):
 
 if len(include_paths) > 0:
     args = " ".join(include_paths)
-    os.system("radon cc {0} -n{1} --codeclimate".format(args, threshold))
+    os.system("{0} cc {1} -n{2} --codeclimate".format(binstub, args, threshold))

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -33,8 +33,14 @@ if os.path.exists("/config.json"):
                 python_paths.append(i)
         include_paths = python_paths
 
+    include_paths = config.get("include_paths", ["."])
+    include_paths = [shlex.quote(path) for path in include_paths
+                     if os.path.isdir(path) or path.endswith(".py")]
+
 if len(include_paths) > 0:
-    paths = " ".join(shlex.quote(path) for path in include_paths)
+    paths = " ".join(include_paths)
 
     print("Running {0}...".format(binstub), file = sys.stderr)
     os.system("{0} cc {1} -n{2} --codeclimate".format(binstub, paths, threshold))
+else:
+    print("Empty workspace; skipping...", file = sys.stderr)

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 
 import json
 import os.path

--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -2,6 +2,7 @@
 
 import json
 import os.path
+import shlex
 import sys
 
 threshold = "b"
@@ -33,5 +34,5 @@ if os.path.exists("/config.json"):
         include_paths = python_paths
 
 if len(include_paths) > 0:
-    args = " ".join(include_paths)
-    os.system("{0} cc {1} -n{2} --codeclimate".format(binstub, args, threshold))
+    paths = " ".join(shlex.quote(path) for path in include_paths)
+    os.system("{0} cc {1} -n{2} --codeclimate".format(binstub, paths, threshold))


### PR DESCRIPTION
Install Python 2.7 onto the Docker image and allow a user to specify which version of Python should be used in analysis when running via Code Climate.

* Switch base image to python:3.5.1-slim
* Shell-escape paths for os.system
* Skip analysis when provided an empty list of paths