### PR TITLE
Make radon eggsecutable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(name='radon',
       install_requires=['mando>=0.3,<0.4', 'colorama>=0.3,<0.4'],
       entry_points={
           'console_scripts': ['radon = radon:main'],
+          'setuptools.installation': [
+              'eggsecutable = radon:main',
+          ],
           'flake8.extension': [
               'R70 = radon.complexity:Flake8Checker',
           ],


### PR DESCRIPTION
As broken as Python packaging is, this is supposed to make radon's egg
executable when installed e.g. as a `setup_requires` or `tests_require`
dependency.