### PR TITLE
Add fingerprint to Code Climate issues

### DIFF
--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -231,7 +231,8 @@ class TestDictConversion(unittest.TestCase):
                                 "location": { "path": "filename", "lines": {"begin": 12, "end": 16}},
                                 "type":"issue",
                                 "categories": ["Complexity"],
-                                "remediation_points": 1100000
+                                "remediation_points": 1100000,
+                                "fingerprint": "3d81e9c72170d2ec9588127b8a43fa26"
                                 }),
                             json.dumps({
                                 "description":"Cyclomatic complexity is too high in class Classname. (8)",
@@ -240,7 +241,8 @@ class TestDictConversion(unittest.TestCase):
                                 "location": {"path": "filename", "lines": {"begin": 17, "end": 29}},
                                 "type":"issue",
                                 "categories": ["Complexity"],
-                                "remediation_points": 1300000
+                                "remediation_points": 1300000,
+                                "fingerprint": "3d81e9c72170d2ec9588127b8a43fa26"
                                 }),
                             ]
 


### PR DESCRIPTION
Adding this fingerprint allows Code Climate to better identify issues.
These are used to allow users to exclude issues from future analysis.
This algorithm is [the current default][algorithm] for Code Climate, but
will change in the future, so we need to retain it here.

[algorithm]: https://github.com/codeclimate/codeclimate/blob/43459efa8bcf6f55af35638ed310fd5b3f8a4f87/lib/cc/analyzer/issue.rb#L41-L47