### PR TITLE
Ensure that error issues have integer location values

### DIFF
--- a/radon/cli/tools.py
+++ b/radon/cli/tools.py
@@ -141,7 +141,7 @@ def dict_to_codeclimate_issues(results, threshold='B'):
             error_category = 'Bug Risk'
 
             if beginline:
-                beginline = beginline.group()
+                beginline = int(beginline.group())
             else:
                 beginline = 1
 

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -221,6 +221,38 @@ class TestDictConversion(unittest.TestCase):
                               </metric>
                             </ccm>'''.replace('\n', '').replace(' ', ''))
 
+
+    def test_cc_error_to_codeclimate(self):
+        error_result = {
+            'error': 'Error: invalid syntax (<unknown>, line 100)'
+        }
+
+        expected_results = [
+                            json.dumps({
+                                "description":"Error: Error: invalid syntax (<unknown>, line 100)",
+                                "check_name":"Complexity",
+                                "content": { "body": "We encountered an error attempting to analyze this line." },
+                                "location": { "path": "filename", "lines": {"begin": 100, "end": 100}},
+                                "type":"issue",
+                                "categories": ["Bug Risk"],
+                                "remediation_points": 1000000,
+                                "fingerprint": "10ac332cd7f638664e8865b098a1707c"
+                                }),
+                            ]
+
+        actual_results = tools.dict_to_codeclimate_issues({"filename": error_result})
+
+        actual_sorted = []
+        for i in actual_results:
+             actual_sorted.append(json.loads(i))
+
+        expected_sorted = []
+        for i in expected_results:
+             expected_sorted.append(json.loads(i))
+
+        self.assertEqual(actual_sorted, expected_sorted)
+
+
     def test_cc_to_codeclimate(self):
         actual_results = tools.dict_to_codeclimate_issues({'filename': CC_TO_CODECLIMATE_CASE})
         expected_results = [


### PR DESCRIPTION
The Code Climate Platform expects that engines emit location data with integer values only. Radon is in complete compliance with the spec with the slight exception of the error result that generates a custom issue from the error details.

This commit casts the captured line number (grabbed from the error content) to an int, before it's passed off to the issue formatter.