### PR TITLE
Closes rubik/radon#86

### DIFF
--- a/radon/cli/tools.py
+++ b/radon/cli/tools.py
@@ -1,6 +1,9 @@
-'''This module contains various utility functions used in the CLI interface.'''
+'''This module contains various utility functions used in the CLI interface.
+Attributes:
+    _encoding (str): encoding with all files will be opened. Configurate by envinronemt variable RADONFILESENCODING'''
 
 import hashlib
+import locale
 import os
 import re
 import sys
@@ -14,6 +17,13 @@ from radon.cli.colors import (LETTERS_COLORS, RANKS_COLORS, TEMPLATE, BRIGHT,
                               RESET)
 
 
+# Add customize file encoding to fix https://github.com/rubik/radon/issues/86
+# By default `open()` function using `locale.getpreferredencoding(False)`
+# encdoing (see https://docs.python.org/3/library/functions.html#open).
+# This code allow to change `open()` encoding by setting it in envinronment
+# variable.
+_encoding = os.getenv('RADONFILESENCODING', locale.getpreferredencoding(False))
+
 @contextmanager
 def _open(path):
     '''Mock of the built-in `open()` function. If `path` is `-` then
@@ -22,7 +32,7 @@ def _open(path):
     if path == '-':
         yield sys.stdin
     else:
-        with open(path) as f:
+        with open(path, encoding=_encoding) as f:
             yield f
 
 

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -1,3 +1,4 @@
+import locale
 import os
 import sys
 import json
@@ -36,7 +37,10 @@ class TestGenericTools(unittest.TestCase):
         m = mock.mock_open()
         with mock.patch('radon.cli.tools.open', m, create=True):
             tools._open('randomfile.py').__enter__()
-        m.assert_called_with('randomfile.py')
+
+        except_encoding = os.getenv('RADONFILESENCODING',
+                                    locale.getpreferredencoding(False))
+        m.assert_called_with('randomfile.py', encoding=except_encoding)
 
 
 class TestIterFilenames(unittest.TestCase):

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -1,5 +1,6 @@
 import locale
 import os
+import platform
 import sys
 import json
 import unittest
@@ -38,9 +39,12 @@ class TestGenericTools(unittest.TestCase):
         with mock.patch('radon.cli.tools.open', m, create=True):
             tools._open('randomfile.py').__enter__()
 
-        except_encoding = os.getenv('RADONFILESENCODING',
-                                    locale.getpreferredencoding(False))
-        m.assert_called_with('randomfile.py', encoding=except_encoding)
+        if platform.python_implementation() == "PyPy":
+            m.assert_called_with('randomfile.py')
+        else:
+            except_encoding = os.getenv('RADONFILESENCODING',
+                                        locale.getpreferredencoding(False))
+            m.assert_called_with('randomfile.py', encoding=except_encoding)
 
 
 class TestIterFilenames(unittest.TestCase):


### PR DESCRIPTION
By default `open()` function using `locale.getpreferredencoding(False)`
encdoing (see https://docs.python.org/3/library/functions.html#open).
On not english versions Windows `locale.getpreferredencoding(False)`
return a strange encodings, like 'cp1251' on russian version.
There is no way to change `locale.getpreferredencoding(False)` to utf-8 on Windows.
This modification allow to change `cli.tools.open()` encoding by setting
it in envinronment variable RADONFILESENCODING.
For example:
```
D:\>type test.py
def a():
"not latin utf-8 char ╨Ш"
print(1)
D:\>radon cc test.py
test.py
ERROR: 'charmap' codec can't decode byte 0x98 in position 34: character
maps to <undefined>

D:\>set RADONFILESENCODING=utf-8

D:\>radon cc test.py
test.py
F 1:0 a - A

D:\>
```