### PR TITLE
Updated Dockerfile for Code Climate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
-FROM python:3.5.1-slim
+FROM alpine:edge
 MAINTAINER rubik
 
 WORKDIR /usr/src/app
-
-RUN apt-get update && \
-  apt-get install -y python2.7 python-pip && \
-  apt-get clean
-
-COPY tox_requirements.txt /usr/src/app/
-RUN pip install --quiet --requirement tox_requirements.txt
-RUN pip2 install --quiet --requirement tox_requirements.txt
-
-RUN adduser -u 9000 app
-
 COPY . /usr/src/app
-RUN pip install --quiet . && \
-  mv /usr/local/bin/radon /usr/local/bin/radon3
-RUN pip2 install --quiet . && \
-  mv /usr/local/bin/radon /usr/local/bin/radon2
+
+RUN apk --update add \
+  python2 python3 py2-pip && \
+  pip2 install --upgrade pip && \
+  pip2 install --requirement tox_requirements.txt && \
+  pip2 install . && \
+  mv /usr/bin/radon /usr/bin/radon2 && \
+  pip3 install --requirement tox_requirements.txt && \
+  pip3 install . && \
+  mv /usr/bin/radon /usr/bin/radon3 && \
+  rm /var/cache/apk/*
+
+RUN adduser -u 9000 app -D
+USER app
 
 WORKDIR /code
-
-USER app
 
 VOLUME /code
 


### PR DESCRIPTION
* Bumped Python 3 to 3.5.2
* Bumped Python 2 to 2.7.13
* Switched base to alpine. Now image is 4x smaller (118.3 MiB vs 482.2 MiB)

Code Climate will use current master (3ab8c78).

I tested the image in both py3 and py2 modes.