### PR TITLE
Adds support for python 3.6 in Code Climate

### DIFF
--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 import json
 import os.path


### PR DESCRIPTION
### Changes ###
* Updates `codeclimate-radon` to not refer to specific python3.x version
* Will effectively bump python from `3.5.2` to `3.6.1` when incorporated in Code Climate

### Details ###
This should address the string interpolation issue here: https://github.com/rubik/radon/issues/108

Alpine edge now uses python version`3.6.1` for the [python3 package](https://pkgs.alpinelinux.org/packages?name=python3&branch=edge&repo=&arch=&maintainer=).
Since the Dockerfile builds from [alpine:edge](https://github.com/rubik/radon/blob/master/Dockerfile#L1), just rebuilding the docker image will update python to 3.6.1:
```
(16/16) Installing python3 (3.6.1-r2)
```
However `codeclimate-radon` has an explicit reference to `python3.5`, which doesn't work after the update. I replaced it with the symlinked `python3` rather than `python3.6` which should be more flexible going forward.

If this looks good, when it's merged I will update Code Climate to reference the commit sha on master.  This will incorporate the commits following our [last update](https://github.com/rubik/radon/commit/46b63901edb68a40c7168a1221eaa38c14cfa7d8) so it will bring us up to v1.5.0 (plus the few more recent commits).