### PR TITLE
Code Climate wrapper: fix some config support

### DIFF
--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -19,9 +19,9 @@ if os.path.exists("/config.json"):
 
         if config["config"].get("python_version"):
             version = config["config"].get("python_version")
-            if version == "2":
+            if version == "2" or version == 2:
                 binstub = "radon2"
-            elif version != "3":
+            elif version != "3" and version != 3:
                 sys.exit("Invalid python_version; must be either 2 or 3")
         if config["config"].get("encoding"):
             encoding = config["config"].get("encoding")


### PR DESCRIPTION
We're in the process of improving how we handle configurations, and ran into this. A defect in our old config handling code meant that many non-stringy values got coerced into strings, including numbers & bools. That was undesirable behavior, but unfortunately we were depending on it here by only comparing the user's specified `python_version` to potential string values.

This change will allow the Radon engine to work with our fixed config code that doesn't coerce these values, while remaining compatible with older versions of our CLI that will still be coercing these values.