### PR TITLE
Add Halstead command (#125)

### DIFF
--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -6,7 +6,7 @@ from mando import Program
 
 import radon.complexity as cc_mod
 from radon.cli.colors import BRIGHT, RED, RESET
-from radon.cli.harvest import CCHarvester, RawHarvester, MIHarvester
+from radon.cli.harvest import CCHarvester, RawHarvester, MIHarvester, HCHarvester
 
 
 program = Program(version=sys.modules['radon'].__version__)
@@ -127,6 +127,27 @@ def mi(paths, min='A', max='C', multi=True, exclude=None, ignore=None,
     harvester = MIHarvester(paths, config)
     log_result(harvester, json=json)
 
+
+@program.command
+@program.arg("paths", nargs="+")
+def hal(paths):
+    """
+    Analyze the given Python modules and compute their Halstead metrics.
+
+    The Halstead metrics are a series of measurements meant to quantitatively
+    measure the complexity of code, including the difficulty a programmer would
+    have in writing it.
+
+    :param paths: The paths where to find modules or packages to analyze. More
+        than one path is allowed.
+    """
+    config = Config(
+                exclude=None,
+                ignore=None
+            )
+
+    harvester = HCHarvester(paths, config)
+    log_result(harvester)
 
 class Config(object):
     '''An object holding config values.'''

--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -3,7 +3,7 @@
 import json
 import collections
 from radon.raw import analyze
-from radon.metrics import mi_visit, mi_rank
+from radon.metrics import h_visit, mi_visit, mi_rank
 from radon.complexity import (cc_visit, sorted_results, cc_rank,
                               add_inner_blocks)
 from radon.cli.colors import RANKS_COLORS, MI_RANKS, RESET
@@ -278,3 +278,29 @@ class MIHarvester(Harvester):
             if self.config.show:
                 to_show = ' ({0:.2f})'.format(mi['mi'])
             yield '{0} - {1}{2}{3}{4}', (name, color, rank, to_show, RESET), {}
+
+
+class HCHarvester(Harvester):
+    """Computes the Halstead Complexity of Python modules."""
+
+    def gobble(self, fobj):
+        """Analyze the content of the file object."""
+        code = fobj.read()
+        return h_visit(code)
+
+    def to_terminal(self):
+        """Yield lines to be printed to the terminal."""
+        for name, res in self.results:
+            yield "{}:".format(name), (), {}
+            yield "h1: {}".format(res.h1), (), {"indent": 1}
+            yield "h2: {}".format(res.h2), (), {"indent": 1}
+            yield "N1: {}".format(res.N1), (), {"indent": 1}
+            yield "N2: {}".format(res.N2), (), {"indent": 1}
+            yield "vocabulary: {}".format(res.vocabulary), (), {"indent": 1}
+            yield "length: {}".format(res.length), (), {"indent": 1}
+            yield "calculated_length: {}".format(res.calculated_length), (), {"indent": 1}
+            yield "volume: {}".format(res.volume), (), {"indent": 1}
+            yield "difficulty: {}".format(res.difficulty), (), {"indent": 1}
+            yield "effort: {}".format(res.effort), (), {"indent": 1}
+            yield "time: {}".format(res.time), (), {"indent": 1}
+            yield "bugs: {}".format(res.bugs), (), {"indent": 1}


### PR DESCRIPTION
This pull request is in reference to issue #125. It adds the rudimentary command `radon hal` to print the Halstead complexity measures for a file on the command line. There are features that would be nice to have (e.g., printing the complexity measures for functions, similar to the cyclomatic complexity command), but I think that this duplicates the existing capability of `h_visit`.

@rubik, in #125 you stated that this feature would need to use the `Harvester` API. Is this what you had in mind?