### PR TITLE
Add --json, --exclude, and --ignore to `radon hal`

### DIFF
--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -130,7 +130,7 @@ def mi(paths, min='A', max='C', multi=True, exclude=None, ignore=None,
 
 @program.command
 @program.arg("paths", nargs="+")
-def hal(paths):
+def hal(paths, exclude=None, ignore=None, json=False):
     """
     Analyze the given Python modules and compute their Halstead metrics.
 
@@ -140,14 +140,21 @@ def hal(paths):
 
     :param paths: The paths where to find modules or packages to analyze. More
         than one path is allowed.
+    :param -e, --exclude <str>: Exclude files only when their path matches one
+        of these glob patterns. Usually needs quoting at the command line.
+    :param -i, --ignore <str>: Ignore directories when their name matches one
+        of these glob patterns: radon won't even descend into them. By default,
+        hidden directories (starting with '.') are ignored.
+    :param -j, --json: Format results in JSON.
     """
     config = Config(
-                exclude=None,
-                ignore=None
+                exclude=exclude,
+                ignore=ignore
             )
 
     harvester = HCHarvester(paths, config)
-    log_result(harvester)
+    log_result(harvester, json=json, xml=False)
+
 
 class Config(object):
     '''An object holding config values.'''

--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -288,6 +288,11 @@ class HCHarvester(Harvester):
         code = fobj.read()
         return h_visit(code)
 
+    def as_json(self):
+        """Format the results as JSON."""
+        result_dict = self._to_dicts()
+        return json.dumps(result_dict)
+
     def to_terminal(self):
         """Yield lines to be printed to the terminal."""
         for name, res in self.results:
@@ -304,3 +309,14 @@ class HCHarvester(Harvester):
             yield "effort: {}".format(res.effort), (), {"indent": 1}
             yield "time: {}".format(res.time), (), {"indent": 1}
             yield "bugs: {}".format(res.bugs), (), {"indent": 1}
+
+    def _to_dicts(self):
+        '''Format the results as a dictionary of dictionaries.'''
+        result = {}
+        for filename, results in self.results:
+            if 'error' in results:
+                result[filename] = results
+            else:
+                result[filename] = results._asdict()
+
+        return result


### PR DESCRIPTION
This adds some flexibility to the `radon hal` option for Halstead complexity.