### PR TITLE
Add Codacy to the Readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,11 @@ one.
 
 If you are looking for more complete solutions, read the following sections.
 
+Codacy
+++++++++++++
+
+`Codacy <https://www.codacy.com/>`_ uses Radon `by default <https://support.codacy.com/hc/en-us/articles/213632009-Engines#other-tools>`_ to calculate metrics from the source code.
+
 Code Climate
 ++++++++++++
 


### PR DESCRIPTION
Codacy uses Radon by default to calculate metrics for python projects therefore, it would be cool to have it listed on the readme file. 👍 

Thanks!