### PR TITLE
add a __main__ module

### DIFF
--- a/radon/__main__.py
+++ b/radon/__main__.py
@@ -1,0 +1,4 @@
+"""Module allowing for ``python -m radon ...``."""
+from radon import main
+
+main()


### PR DESCRIPTION
so a "python -m radon" works as expected.