### PR TITLE
Fix indentation for flake8 doc

### DIFF
--- a/docs/flake8.rst
+++ b/docs/flake8.rst
@@ -19,8 +19,9 @@ following options:
    Instruct radon not to count `assert` statements towards cyclomatic
    complexity. The default behaviour is the opposite.
 
- .. option:: --radon-show-closures
-    Instruct radon to add closures/inner classes to the output.
+.. option:: --radon-show-closures
+
+   Instruct radon to add closures/inner classes to the output.
 
 For more information visit the `Flake8 documentation
 <http://flake8.readthedocs.org/en/latest/>`_.


### PR DESCRIPTION
This pull request removes an additional space and adds an empty line. The current setting causes wrong indentation, as visible here: https://radon.readthedocs.io/en/latest/flake8.html