### PR TITLE
Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
     - "pypy3.5"
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial
-          sudo: true
 install:
     - pip install .
     - pip install -r test_requirements.txt

--- a/radon/visitors.py
+++ b/radon/visitors.py
@@ -288,9 +288,9 @@ class HalsteadVisitor(CodeVisitor):
     Halstead metrics (see :func:`radon.metrics.h_visit`).
     '''
 
-    types = {ast.Num: 'n',
-             ast.Name: 'id',
-             ast.Attribute: 'attr'}
+    # As of Python 3.8 Num/Str/Bytes/NameConstat
+    # are now in a common node Constant.
+    types = {"Num": "n", "Name": "id", "Attribute": "attr", "Constant": "value"}
 
     def __init__(self, context=None):
         '''*context* is a string used to keep track the analysis' context.'''
@@ -333,6 +333,8 @@ class HalsteadVisitor(CodeVisitor):
                 new_operand = getattr(operand,
                                       self.types.get(type(operand), ''),
                                       operand)
+                name = self.get_name(operand)
+                new_operand = getattr(operand, self.types.get(name, ""), operand)
 
                 self.operands_seen.add((self.context, new_operand))
             # Now dispatch to children

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mando>=0.6,<0.7
-colorama>=0.4,<0.5
+colorama==0.4.2
 flake8_polyfill
 future

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mando>=0.6,<0.7
-colorama==0.4.2
+colorama==0.4.1
 flake8_polyfill
 future

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='radon',
       tests_require=['tox'],
       install_requires=[
           'mando>=0.6,<0.7',
-          'colorama==0.4.2',
+          'colorama==0.4.1',
           'flake8-polyfill',
           'future',
       ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='radon',
       tests_require=['tox'],
       install_requires=[
           'mando>=0.6,<0.7',
-          'colorama>=0.4,<0.5',
+          'colorama==0.4.2',
           'flake8-polyfill',
           'future',
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy
+envlist = py27,py33,py34,py35,py36,py37,py38,pypy
 
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt


### PR DESCRIPTION
Fixes #183

_From the docs:_ 
Deprecated since version 3.8: Class ast.Constant is now used for all constants. Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and ast.Ellipsis are still available, but they will be removed in future Python releases.

This caused numbers to be ignored for the Halstead Metrics.

All tests pass now for Python 3.8. 
