### PR TITLE
Move `Flake8Checker` into separete module

### DIFF
--- a/radon/complexity.py
+++ b/radon/complexity.py
@@ -4,8 +4,6 @@ Cyclomatic Complexity
 
 import math
 
-from flake8_polyfill import options
-
 from radon.visitors import GET_COMPLEXITY, ComplexityVisitor, code2ast
 
 # sorted_block ordering functions
@@ -108,76 +106,3 @@ def cc_visit_ast(ast_node, **kwargs):
     the keyword arguments are directly passed to the visitor.
     '''
     return ComplexityVisitor.from_ast(ast_node, **kwargs).blocks
-
-
-class Flake8Checker(object):
-    '''Entry point for the Flake8 tool.'''
-
-    name = 'radon'
-    version = __import__('radon').__version__
-    _code = 'R701'
-    _error_tmpl = 'R701 %r is too complex (%d)'
-    no_assert = False
-    show_closures = False
-    max_cc = -1
-
-    def __init__(self, tree, filename):
-        '''Accept the AST tree and a filename (unused).'''
-        self.tree = tree
-
-    @classmethod
-    def add_options(cls, parser):  # pragma: no cover
-        '''Add custom options to the global parser.'''
-        options.register(
-            parser,
-            '--radon-max-cc',
-            default=-1,
-            action='store',
-            type='int',
-            help='Radon complexity threshold',
-            parse_from_config=True,
-        )
-        options.register(
-            parser,
-            '--radon-no-assert',
-            dest='no_assert',
-            action='store_true',
-            default=False,
-            help='Radon will ignore assert statements',
-            parse_from_config=True,
-        )
-        options.register(
-            parser,
-            '--radon-show-closures',
-            dest='show_closures',
-            action='store_true',
-            default=False,
-            help='Add closures/inner classes to the output',
-            parse_from_config=True,
-        )
-
-    @classmethod
-    def parse_options(cls, options):  # pragma: no cover
-        '''Save actual options as class attributes.'''
-        cls.max_cc = options.radon_max_cc
-        cls.no_assert = options.no_assert
-        cls.show_closures = options.show_closures
-
-    def run(self):
-        '''Run the ComplexityVisitor over the AST tree.'''
-        if self.max_cc < 0:
-            if not self.no_assert:
-                return
-            self.max_cc = 10
-        visitor = ComplexityVisitor.from_ast(
-            self.tree, no_assert=self.no_assert
-        )
-
-        blocks = visitor.blocks
-        if self.show_closures:
-            blocks = add_inner_blocks(blocks)
-
-        for block in blocks:
-            if block.complexity > self.max_cc:
-                text = self._error_tmpl % (block.name, block.complexity)
-                yield block.lineno, block.col_offset, text, type(self)

--- a/radon/contrib/flake8.py
+++ b/radon/contrib/flake8.py
@@ -1,0 +1,77 @@
+from flake8_polyfill import options
+
+from radon.complexity import add_inner_blocks
+from radon.visitors import ComplexityVisitor
+
+
+class Flake8Checker(object):
+    '''Entry point for the Flake8 tool.'''
+
+    name = 'radon'
+    version = __import__('radon').__version__
+    _code = 'R701'
+    _error_tmpl = 'R701 %r is too complex (%d)'
+    no_assert = False
+    show_closures = False
+    max_cc = -1
+
+    def __init__(self, tree, filename):
+        '''Accept the AST tree and a filename (unused).'''
+        self.tree = tree
+
+    @classmethod
+    def add_options(cls, parser):  # pragma: no cover
+        '''Add custom options to the global parser.'''
+        options.register(
+            parser,
+            '--radon-max-cc',
+            default=-1,
+            action='store',
+            type='int',
+            help='Radon complexity threshold',
+            parse_from_config=True,
+        )
+        options.register(
+            parser,
+            '--radon-no-assert',
+            dest='no_assert',
+            action='store_true',
+            default=False,
+            help='Radon will ignore assert statements',
+            parse_from_config=True,
+        )
+        options.register(
+            parser,
+            '--radon-show-closures',
+            dest='show_closures',
+            action='store_true',
+            default=False,
+            help='Add closures/inner classes to the output',
+            parse_from_config=True,
+        )
+
+    @classmethod
+    def parse_options(cls, options):  # pragma: no cover
+        '''Save actual options as class attributes.'''
+        cls.max_cc = options.radon_max_cc
+        cls.no_assert = options.no_assert
+        cls.show_closures = options.show_closures
+
+    def run(self):
+        '''Run the ComplexityVisitor over the AST tree.'''
+        if self.max_cc < 0:
+            if not self.no_assert:
+                return
+            self.max_cc = 10
+        visitor = ComplexityVisitor.from_ast(
+            self.tree, no_assert=self.no_assert
+        )
+
+        blocks = visitor.blocks
+        if self.show_closures:
+            blocks = add_inner_blocks(blocks)
+
+        for block in blocks:
+            if block.complexity > self.max_cc:
+                text = self._error_tmpl % (block.name, block.complexity)
+                yield block.lineno, block.col_offset, text, type(self)

--- a/radon/tests/test_complexity_utils.py
+++ b/radon/tests/test_complexity_utils.py
@@ -4,6 +4,7 @@ import operator
 import pytest
 
 from radon.complexity import *
+from radon.contrib.flake8 import Flake8Checker
 from radon.visitors import Class, Function
 
 from .test_complexity_visitor import GENERAL_CASES, dedent

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='radon',
               'eggsecutable = radon:main',
           ],
           'flake8.extension': [
-              'R70 = radon.complexity:Flake8Checker [flake8]',
+              'R70 = radon.contrib.flake8:Flake8Checker [flake8]',
           ],
       },
       keywords='static analysis code complexity metrics',


### PR DESCRIPTION
Due to extraction of `flake8_polyfill` into extra requirement, it's import in `radon.complexity` should be conditional. As a consequences, the whole `Flake8Checker` should be conditional, too. Because it's dependent on this import. It is much easier to move the whole thing into it's own module, rather than check for presence of `flake8_polyfill`. It is guaranteed that this module would be imported only by `flake8`, when extra requirement is installed.

Another option would be to check for presence of `flake8_polyfill` and then create the class:

```python
# move import to class declaration
try:
    from flake8_polyfill import options
except ImportError:
    pass
else:
    class Flake8Checker(object):
    <...>
```
