### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 os: linux
+arch:
+ - amd64
+ - ppc64le
 dist: xenial
 python:
     - "2.7"
@@ -7,6 +10,10 @@ python:
     - "3.7"
     - "3.8"
     - "pypy3.5"
+matrix:
+  exclude:
+  - arch: ppc64le
+    python: pypy3.5    
 install:
     - pip install .[flake8]
     - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   exclude:
   - arch: ppc64le
     python: pypy3.5    
+  - arch: ppc64le
+    python: 2.7    
 install:
     - pip install .[flake8]
     - pip install -r test_requirements.txt


### PR DESCRIPTION
Add support for architecture ppc64le.  

Exclude python "pypy3.5" and "2.7" for ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
