### PR TITLE
Fix CC Mardown type field value

### DIFF
--- a/radon/cli/tools.py
+++ b/radon/cli/tools.py
@@ -355,6 +355,9 @@ def dict_to_md(results):
 | Filename | Name | Type | Start:End Line | Complexity | Clasification |
 | -------- | ---- | ---- | -------------- | ---------- | ------------- |
 '''
+    type_letter_map = {'class': 'C',
+                       'method': 'M',
+                       'function': 'F'}
     for filename, blocks in results.items():
         for block in blocks:
             raw_classname = block.get("classname")
@@ -362,13 +365,7 @@ def dict_to_md(results):
             name = "{}.{}".format(
                 raw_classname,
                 raw_name) if raw_classname else block["name"]
-            raw_is_method = block.get("is_method")
-            if raw_classname and raw_is_method:
-                type = "M"
-            elif raw_is_method is None:
-                type = "C"
-            else:
-                type = "F"
+            type = type_letter_map[block["type"]]
             md_string += "| {} | {} | {} | {}:{} | {} | {} |\n".format(
                 filename,
                 name,

--- a/radon/tests/test_cli_tools.py
+++ b/radon/tests/test_cli_tools.py
@@ -379,19 +379,26 @@ def test_cc_to_xml():
     )
 
 
+CC_TO_MD_RESULTS = [
+    {"type": "method", "rank": "A", "lineno": 110, "classname": "Classname", "endline": 117,
+     "complexity": 2, "name": "flush", "col_offset": 4},
+    {"type": "class", "rank": "B", "lineno": 73, "endline": 124, "complexity": 4, "name": "Classname",
+     "col_offset": 0},
+    {'type': 'function', 'rank': 'C', 'lineno': 62, 'endline': 69, 'complexity': 10, 'name': 'decrement',
+     'col_offset': 0}
+]
+
+
 def test_cc_to_md():
-    assert (
-        tools.dict_to_md({'filename': CC_TO_XML_CASE})
-        == '''
+    md = tools.dict_to_md({'filename': CC_TO_MD_RESULTS})
+    _md = '''
 | Filename | Name | Type | Start:End Line | Complexity | Clasification |
 | -------- | ---- | ---- | -------------- | ---------- | ------------- |
-| filename | name | F | 12:16 | 6 | B |
-| filename | Classname | C | 17:29 | 8 | B |
-| filename | Classname.name | M | 19:26 | 7 | B |
-| filename | aux | F | 13:17 | 4 | A |
-| filename | name | F | 12:16 | 10 | B |
+| filename | Classname.flush | M | 110:117 | 2 | A |
+| filename | Classname | C | 73:124 | 4 | B |
+| filename | decrement | F | 62:69 | 10 | C |
 '''
-    )
+    assert md == _md
 
 
 def test_cc_error_to_codeclimate():


### PR DESCRIPTION
I encountered a small bug inspecting a library by `radon cc --md`. All the `Type` field values were identical to `C`.

How it looked like:

| Filename | Name | Type | Start:End Line | Complexity | Clasification |
| -------- | ---- | ---- | -------------- | ---------- | ------------- |
| tinydb/middlewares.py | CachingMiddleware.flush | C | 110:117 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.write | C | 101:108 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.read | C | 93:99 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware | C | 73:124 | 2 | A |
| tinydb/middlewares.py | Middleware | C | 7:70 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.close | C | 119:124 | 1 | A |
| tinydb/middlewares.py | CachingMiddleware.__init__ | C | 85:91 | 1 | A |
| tinydb/middlewares.py | Middleware.__getattr__ | C | 64:70 | 1 | A |
| tinydb/middlewares.py | Middleware.__call__ | C | 22:62 | 1 | A |
| tinydb/middlewares.py | Middleware.__init__ | C | 18:20 | 1 | A |
| tinydb/operations.py | decrement | C | 62:69 | 1 | A |


How it looks now:

| Filename | Name | Type | Start:End Line | Complexity | Clasification |
| -------- | ---- | ---- | -------------- | ---------- | ------------- |
| tinydb/middlewares.py | CachingMiddleware.flush | M | 110:117 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.write | M | 101:108 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.read | M | 93:99 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware | C | 73:124 | 2 | A |
| tinydb/middlewares.py | Middleware | C | 7:70 | 2 | A |
| tinydb/middlewares.py | CachingMiddleware.close | M | 119:124 | 1 | A |
| tinydb/middlewares.py | CachingMiddleware.__init__ | M | 85:91 | 1 | A |
| tinydb/middlewares.py | Middleware.__getattr__ | M | 64:70 | 1 | A |
| tinydb/middlewares.py | Middleware.__call__ | M | 22:62 | 1 | A |
| tinydb/middlewares.py | Middleware.__init__ | M | 18:20 | 1 | A |
| tinydb/operations.py | decrement | F | 62:69 | 1 | A |
