### PR TITLE
Drop support for flake8 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.9"
     - "pypy3.5"
 install:
-    - pip install .[flake8]
+    - pip install .
     - pip install -r test_requirements.txt
 script:
     - make tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+5.0.0 (Jun 8, 2021)
+--------------------
+
+- Drop support for flake8 < 3.x (removes `flake8-polyfill` dependency)
+
 4.5.2 (May 23, 2021)
 --------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 5.0.0 (Jun 8, 2021)
 --------------------
 
-- Drop support for flake8 < 3.x (removes `flake8-polyfill` dependency)
+- Drop support for flake8 < 3.x (removes `flake8-polyfill` dependency), by
+  @joxl: #219
 
 4.5.2 (May 23, 2021)
 --------------------

--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,3 @@ pytest-mock = "*"
 [packages]
 mando = ">=0.3,<0.4"
 colorama = ">=0.3,<0.4"
-flake8-polyfill = "*"

--- a/radon/__init__.py
+++ b/radon/__init__.py
@@ -1,7 +1,7 @@
 '''This module contains the main() function, which is the entry point for the
 command line interface.'''
 
-__version__ = '4.5.2'
+__version__ = '5.0.0'
 
 
 def main():

--- a/radon/contrib/flake8.py
+++ b/radon/contrib/flake8.py
@@ -1,5 +1,3 @@
-from flake8_polyfill import options
-
 from radon.complexity import add_inner_blocks
 from radon.visitors import ComplexityVisitor
 
@@ -20,19 +18,17 @@ class Flake8Checker(object):
         self.tree = tree
 
     @classmethod
-    def add_options(cls, parser):  # pragma: no cover
+    def add_options(cls, option_manager):  # pragma: no cover
         '''Add custom options to the global parser.'''
-        options.register(
-            parser,
+        option_manager.add_option(
             '--radon-max-cc',
             default=-1,
             action='store',
-            type='int',
+            type=int,
             help='Radon complexity threshold',
             parse_from_config=True,
         )
-        options.register(
-            parser,
+        option_manager.add_option(
             '--radon-no-assert',
             dest='no_assert',
             action='store_true',
@@ -40,8 +36,7 @@ class Flake8Checker(object):
             help='Radon will ignore assert statements',
             parse_from_config=True,
         )
-        options.register(
-            parser,
+        option_manager.add_option(
             '--radon-show-closures',
             dest='show_closures',
             action='store_true',

--- a/radon/tests/run.py
+++ b/radon/tests/run.py
@@ -1,5 +1,14 @@
 if __name__ == '__main__':
     import pytest
 
-    ret = pytest.main(['--strict'])
+    # see: https://docs.pytest.org/en/6.2.x/deprecations.html#the-strict-command-line-option
+    # This check can be removed once Python 2.x support is dropped as the new
+    # pytest option (--strict-markers) is available in pytest for all Python 3.x
+    from packaging import version
+    if version.parse(pytest.__version__) < version.parse('6.2'):
+        pytest_args = ['--strict']
+    else:
+        pytest_args = ['--strict-markers']
+
+    ret = pytest.main(pytest_args)
     exit(ret)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 mando>=0.6,<0.7
 colorama==0.4.1;python_version<='3.4'
 colorama>=0.4.1;python_version>'3.4'
-flake8_polyfill
 future

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(name='radon',
           'colorama==0.4.1;python_version<="3.4"',
           'colorama>=0.4.1;python_version>"3.4"',
           'future',
-          'flake8-polyfill',
       ],
       entry_points={
           'console_scripts': ['radon = radon:main'],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 coverage
 coveralls
-flake8-polyfill
 pytest>=5.0; python_version >= '3.0'
 pytest>=2.7; python_version < '3.0'
 pytest-mock


### PR DESCRIPTION
Drops support for flake8 2.x as mentioned in https://github.com/rubik/radon/issues/217#issuecomment-846799621

- Bumps version to 5.0.0.
- Tests passing locally on Python 2.7 and 3.6.
- New `Pipfile.lock` was not generated.