### PR TITLE
chore: remove obsolete future dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mando>=0.6,<0.7
 colorama==0.4.1;python_version<='3.4'
 colorama>=0.4.1;python_version>'3.4'
-future

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='radon',
           'mando>=0.6,<0.7',
           'colorama==0.4.1;python_version<="3.4"',
           'colorama>=0.4.1;python_version>"3.4"',
-          'future',
       ],
       entry_points={
           'console_scripts': ['radon = radon:main'],


### PR DESCRIPTION
The `future` package is not used anywhere in the code, so remove
the dependency.