### PR TITLE
pyproject.toml support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ With Pip:
 
     $ pip install radon
 
+With Pip and `pyproject.toml` support on Python <3.11:
+
+.. code-block:: sh
+
+   $ pip install radon[toml]
+
 Or download the source and run the setup file:
 
 .. code-block:: sh

--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -23,6 +23,7 @@ For example, all of the radon commands have a ``--exclude`` and ``--ignore`` arg
 Radon will look for the following files to determine default arguments:
 
 * ``radon.cfg``
+* ``pyproject.toml`` (with optional toml install before python 3.11)
 * ``setup.cfg``
 * ``~/.radon.cfg``
 

--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -6,6 +6,15 @@ import sys
 from contextlib import contextmanager
 
 from mando import Program
+try:
+    # Python 3.11+
+    import tomllib
+except ImportError:
+    try:
+        # Support for python <3.11
+        import tomli as tomllib
+    except ImportError:
+        pass
 
 import radon.complexity as cc_mod
 from radon.cli.colors import BRIGHT, RED, RESET
@@ -50,12 +59,23 @@ class FileConfig(object):
             )
 
     @staticmethod
+    def toml_config():
+        try:
+            with open("pyproject.toml", "rb") as pyproject_file:
+                pyproject = tomllib.load(pyproject_file)
+            config_dict = pyproject["tool"]
+        except Exception:
+            config_dict = {}
+        return config_dict
+
+    @staticmethod
     def file_config():
         '''Return any file configuration discovered'''
         config = configparser.ConfigParser()
         for path in (os.getenv('RADONCFG', None), 'radon.cfg'):
             if path is not None and os.path.exists(path):
                 config.read_file(open(path))
+        config.read_dict(FileConfig.toml_config())
         config.read(['setup.cfg', os.path.expanduser('~/.radon.cfg')])
         return config
 

--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -64,6 +64,8 @@ class FileConfig(object):
             with open("pyproject.toml", "rb") as pyproject_file:
                 pyproject = tomllib.load(pyproject_file)
             config_dict = pyproject["tool"]
+        except tomllib.TOMLDecodeError as exc:
+            raise exc
         except Exception:
             config_dict = {}
         return config_dict

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(name='radon',
           'colorama==0.4.1;python_version<="3.4"',
           'colorama>=0.4.1;python_version>"3.4"',
       ],
+      extras_require={
+          'toml': ["tomli>=2.0.1"]
+      },
       entry_points={
           'console_scripts': ['radon = radon:main'],
           'setuptools.installation': [


### PR DESCRIPTION
Fixes: https://github.com/rubik/radon/issues/220

This enables pyproject.toml support for radon.

Decisions I made the maintainer should be aware of before merging:

- Automatic pyproject.toml support for python 3.11+
- Optional pyproject.toml support for python <3.11 if you install with:
   ```sh 
   pip install radon[toml]
   ```
- Silently ignores pyproject.toml if:
   - no pyproject.toml file is found
   - no toml parsing library is available
- Raises an exception if:
   - toml file is found and is parsed incorrectly.
   
I'm happy to change anything that isn't quite in the spirit of radon.