### PR TITLE
docs: fix typos

### DIFF
--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -52,7 +52,7 @@ class Harvester(object):
        implemented.
 
     3. **Reporting**: the methods *as_json* and *as_xml* return a string
-       with the corrisponding format. The method *to_terminal* is a generator
+       with the corresponding format. The method *to_terminal* is a generator
        that yields the lines to be printed in the terminal.
 
     This class is meant to be subclasses and cannot be used directly, since

--- a/radon/cli/tools.py
+++ b/radon/cli/tools.py
@@ -58,7 +58,7 @@ else:
     )
 
     if sys.version_info[:2] < (2, 7):
-        # This open function treats line-endings slighly differently than
+        # This open function treats line-endings slightly differently than
         # io.open. But the latter is implemented in pure Python in version 2.6,
         # so we'll live with the differences instead of taking a hit on the
         # speed. Radon does a lot of file reading, so the difference in speed
@@ -447,7 +447,7 @@ def dict_to_codeclimate_issues(results, threshold='B'):
 
 
 def cc_to_terminal(results, show_complexity, min, max, total_average):
-    '''Transfom Cyclomatic Complexity results into a 3-elements tuple:
+    '''Transform Cyclomatic Complexity results into a 3-elements tuple:
 
         ``(res, total_cc, counted)``
 

--- a/radon/tests/test_complexity_visitor.py
+++ b/radon/tests/test_complexity_visitor.py
@@ -624,7 +624,7 @@ GENERAL_CASES = [
         '''
      try:
          1 / 0
-     except ZeroDivisonError:
+     except ZeroDivisionError:
          print
      except TypeError:
          pass

--- a/radon/visitors.py
+++ b/radon/visitors.py
@@ -43,13 +43,13 @@ def code2ast(source):
     '''Convert a string object into an AST object.
 
     This function is retained for backwards compatibility, but it no longer
-    attemps any conversions. It's equivalent to a call to ``ast.parse``.
+    attempts any conversions. It's equivalent to a call to ``ast.parse``.
     '''
     return ast.parse(source)
 
 
 class Function(BaseFunc):
-    '''Object represeting a function block.'''
+    '''Object representing a function block.'''
 
     @property
     def letter(self):
@@ -127,7 +127,7 @@ class CodeVisitor(ast.NodeVisitor):
 
     @classmethod
     def from_code(cls, code, **kwargs):
-        '''Instanciate the class from source code (string object). The
+        '''Instantiate the class from source code (string object). The
         `**kwargs` are directly passed to the `ast.NodeVisitor` constructor.
         '''
         return cls.from_ast(code2ast(code), **kwargs)


### PR DESCRIPTION
Found via `codespell -S docs -L ue,hav,ot`