### PR TITLE
Add radon CLI script to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ argparse = "*"
 nbformat = "*"
 tox = "^4.4.7"
 
+[tool.poetry.scripts]
+radon = "radon:main"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The pyproject.toml is missing the tool.poetry.scripts section, which means that builds that rely only on pyproject.toml will not install it.