### PR TITLE
Add clarification about multi-value exclude/ignore

### DIFF
--- a/docs/commandline.rst
+++ b/docs/commandline.rst
@@ -129,6 +129,10 @@ Options
    Exclude files only when their path matches one of these glob patterns.
    Usually needs quoting at the command line.
 
+   This is a comma-separated list. ``--exclude a.py,b.py`` will skip both
+   ``a.py`` and ``b.py``, but ``--exclude a.py --exclude b.py`` will
+   **NOT** exclude ``a.py``.
+
    Value can be set in a configuration file using the ``exclude`` property.
 
 .. option:: -i, --ignore
@@ -136,6 +140,9 @@ Options
    Ignore directories when their name matches one of these glob patterns: radon
    won't even descend into them. By default, hidden directories (starting with
    '.') are ignored.
+
+   This is a comma-separated list. ``--ignore a,b`` will ignore both ``a`` and
+   ``b``, but ``--ignore a --ignore b`` will **NOT** ignore ``a``.
 
    Value can be set in a configuration file using the ``ignore`` property.
 


### PR DESCRIPTION
I don't know if this is the norm in Python or not, but many other command line tools I used accept list by taking multiple arguments after the option, allowing specifying the option multiple times, or comma-separated list like this.

Based on my personal experience, I tried repeating the option multiple times because that's the most common usage I experienced and then immediately got into issues. That's why I want to add this clarification to the docs.