### PR TITLE
Add average to JSON output

### DIFF
--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -185,6 +185,8 @@ class CCHarvester(Harvester):
     def _to_dicts(self):
         '''Format the results as a dictionary of dictionaries.'''
         result = {}
+        average_cc = 0.0
+        analyzed = 0
         for key, data in self.results:
             if 'error' in data:
                 result[key] = data
@@ -196,6 +198,24 @@ class CCHarvester(Harvester):
             ]
             if values:
                 result[key] = values
+            _res, cc, n = cc_to_terminal(
+                data,
+                self.config.show_complexity,
+                self.config.min,
+                self.config.max,
+                self.config.total_average,
+            )
+            average_cc += cc
+            analyzed += n
+
+        if (self.config.average or self.config.total_average) and analyzed:
+            cc = average_cc / analyzed
+            ranked_cc = cc_rank(cc)
+            result['__radon_summary'] = {
+                'blocks': analyzed,
+                'rank': ranked_cc,
+                'cc': cc
+            }
         return result
 
     def as_json(self):


### PR DESCRIPTION
I'm building a report page for Radon analysis result based on the JSON output. However, currently only terminal output has the summary statistics, so here's a PR to add that for JSON output.

I want to change it from `{"<file>": ...}` to `{"files": {"<file>": ...}, "summary": { ... }}`, but that may break existing tools, so I switched to adding a new key instead.

I don't know much about CodeClimate though, so I'm not sure if this PR will break existing functionalities, please let me know if there is something needs fixing.

Old result (Radon 6.0.1):

```json
{
  "env.py": [
    {
      "type": "function",
      "rank": "A",
      "col_offset": 0,
      "endline": 4,
      "name": "load_env",
      "lineno": 1,
      "complexity": 1,
      "closures": []
    }
  ]
}
```

New result (this PR):

```json
{
  "env.py": [
    {
      "type": "function",
      "rank": "A",
      "endline": 4,
      "col_offset": 0,
      "complexity": 1,
      "name": "load_env",
      "lineno": 1,
      "closures": []
    }
  ],
  "__radon_summary": {
    "blocks": 1,
    "rank": "A",
    "cc": 1.0
  }
}
```