### PR TITLE
README: Correct Python version compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,19 +35,12 @@ Radon can compute:
 Requirements
 ------------
 
-Radon will run from **Python 2.7** to **Python 3.10** (except Python versions
-from 3.0 to 3.3) with a single code base and without the need of tools like
-2to3 or six. It can also run on **PyPy** without any problems (currently PyPy
-3.5 v7.3.1 is used in tests).
+Radon runs on **Python 3.7** and newer.
 
 Radon depends on as few packages as possible. Currently only `mando` is
 strictly required (for the CLI interface). `colorama` is also listed as a
 dependency but if Radon cannot import it, the output simply will not be
 colored.
-
-**Note**:
-**Python 2.6** was supported until version 1.5.0. Starting from version 2.0, it
-is not supported anymore.
 
 Installation
 ------------


### PR DESCRIPTION
The current versions of Radon do not run on Python 2.

```
docker run -it python:2.7.10 sh -c 'pip install radon && radon'
Successfully installed colorama-0.4.1 funcsigs-1.0.2 mando-0.7.1 radon-6.0.1 six-1.16.0
$
Traceback (most recent call last):
  File "/usr/local/bin/radon", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/radon/__init__.py", line 10, in main
    from radon.cli import program, log_error
  File "/usr/local/lib/python2.7/site-packages/radon/cli/__init__.py", line 23, in <module>
    from radon.cli.harvest import (
  File "/usr/local/lib/python2.7/site-packages/radon/cli/harvest.py", line 6, in <module>
    from builtins import super
ImportError: No module named builtins
$
```