### PR TITLE
Produce output json in a readable format

### DIFF
--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -198,9 +198,13 @@ class CCHarvester(Harvester):
                 result[key] = values
         return result
 
-    def as_json(self):
+    def as_json(self, _format: bool=False):
         '''Format the results as JSON.'''
-        return json.dumps(self._to_dicts())
+        if _format:
+            return json.dumps(self._to_dicts(), separators=[',', ':'], indent=2)
+        else:
+             return json.dumps(self._to_dicts())
+
 
     def as_xml(self):
         '''Format the results as XML. This is meant to be compatible with


### PR DESCRIPTION
Json output is unreadable.
Although users might be consuming the dictionary itself without looking at output, but it's goot at least to have a formatting option for uses who wish to inspect output json manually.


This is merely a suggestion,  please address as necessary. Thanks