### PR TITLE
Add a GitHub Action to run tox

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,19 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox:
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py


### PR DESCRIPTION
Test results: https://github.com/cclauss/radon/actions
```
============================= test session starts ==============================
platform linux -- Python 3.12.1, pytest-7.4.4, pluggy-1.3.0
cachedir: .tox/py/.pytest_cache
rootdir: /home/runner/work/radon/radon
plugins: mock-3.12.0
collected 404 items

radon/tests/test_cli.py ..............                                   [  3%]
radon/tests/test_cli_colors.py ...                                       [  4%]
radon/tests/test_cli_harvest.py ....................                     [  9%]
radon/tests/test_cli_tools.py ............                               [ 12%]
radon/tests/test_complexity_utils.py ................................... [ 20%]
........................................................................ [ 38%]
....                                                                     [ 39%]
radon/tests/test_complexity_visitor.py ................................. [ 47%]
................................                                         [ 55%]
radon/tests/test_halstead.py ...........                                 [ 58%]
radon/tests/test_ipynb.py .....                                          [ 59%]
radon/tests/test_other_metrics.py ...................................... [ 69%]
........................................................................ [ 86%]
..                                                                       [ 87%]
radon/tests/test_raw.py ................................................ [ 99%]
...                                                                      [100%]

============================= 404 passed in 0.88s ==============================
```