### PR TITLE
Fix incorrect lloc count when there's a colon in the line (fixes #262)

### DIFF
--- a/radon/raw.py
+++ b/radon/raw.py
@@ -29,6 +29,22 @@ __all__ = [
     'analyze',
 ]
 
+COMPOUND_KEYWORDS = {
+    "if",
+    "while",
+    "for",
+    "try",
+    "with",
+    "match",
+    "def",
+    "class",
+    "else",
+    "elif",
+    "except",
+    "finally",
+    "case",
+}
+
 COMMENT = tokenize.COMMENT
 OP = tokenize.OP
 NL = tokenize.NL
@@ -160,7 +176,10 @@ def _logical(tokens):
             # ENDMARKER. There are two cases: if the colon is at the end, it
             # means that there is only one logical line; if it isn't then there
             # are two.
-            return 2 - (token_pos == len(processed) - 2)
+            # Only consider colons when a compound statement is found in the line
+            if any(token.string in COMPOUND_KEYWORDS for token in processed):
+                return 2 - (token_pos == len(processed) - 2)
+            return 1
         except ValueError:
             # The colon is not present
             # If the line is only composed by comments, newlines and endmarker

--- a/radon/tests/test_raw.py
+++ b/radon/tests/test_raw.py
@@ -180,6 +180,38 @@ LOGICAL_LINES_CASES = [
      ''',
         5,
     ),
+    (
+        '''
+     [].sort(key=lambda x: 1)
+     ''',
+        1,
+    ),
+    (
+        '''
+     [1][1:]
+     ''',
+        1,
+    ),
+    (
+        '''
+     a = {'user1': 'password1', 'user2': 'password2'}
+     ''',
+        1,
+    ),
+    (
+        '''
+     def a(b: str\n): pass
+     ''',
+        2,
+    ),
+    # "case" as a variable name with a colon on the same line
+    # (e.g. from a dict) causes a false positive
+    # (
+    #     '''
+    #  case = {'user1': 'password1', 'user2': 'password2'}
+    #  ''',
+    #     1,
+    # ),
 ]
 
 


### PR DESCRIPTION
This PR makes `raw._logical` avoid counting lines with colons as two logical lines unless a compound statement keyword is present.

There's still an issue, because "match" and "case" are soft keywords, so `_logical` will still count 2 llocs on a line like:
```python
case = {1: 2, 3: 4}
```
However, this change makes the count right for the common cases and wrong only for questionable (as in "using soft keywords as variable names") code.

Fixes #262.