### PR TITLE
Implement tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.14', '3.13', '3.12', '3.11', '3.10', 'pypy3.10' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+      - run: rm -f pyproject.toml
+      - run: mv pyproject-uv.toml pyproject.toml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync
+      - run: uv run make tests
+  test_3_7:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - run: rm -f pyproject.toml
+      - run: mv pyproject-uv.toml pyproject.toml
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.7'
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv sync --python '3.7'
+      - run: uv run make tests
+  test_legacy:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        tag-docker-image-python: [ '3.6.15-slim-bullseye', '2.7.18-slim-buster' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build and start Docker Compose services
+        run: docker compose run --rm radon
+        env:
+          TAG_DOCKER_IMAGE_PYTHON: ${{ matrix.tag-docker-image-python }}

--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -1,0 +1,11 @@
+ARG TAG_DOCKER_IMAGE_PYTHON=latest
+FROM python:${TAG_DOCKER_IMAGE_PYTHON}
+WORKDIR /workspace
+COPY Pipfile README.rst /workspace/
+# COPY Pipfile Pipfile.lock README.rst /workspace/
+RUN pip install pipenv==11.10.4 \
+# RUN pip install pipenv==2020.5.28 \
+ && pipenv install --skip-lock --dev --system
+#  && pipenv install --deploy --system
+COPY . /workspace/
+CMD ["python", "radon/tests/run.py"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+services:
+  radon:
+    build:
+      context: .
+      dockerfile: Dockerfile.legacy
+      args:
+        TAG_DOCKER_IMAGE_PYTHON: ${TAG_DOCKER_IMAGE_PYTHON:?err}
+    image: futureys/radon:development
+    volumes:
+      - ./:/workspace:cached
+      - /workspace/.venv

--- a/pyproject-uv.toml
+++ b/pyproject-uv.toml
@@ -1,0 +1,53 @@
+[dependency-groups]
+dev = [
+    "tox",
+    "pytest",
+    "coverage",
+    # 
+    "mando",
+    "mock",
+    "pytest-mock",
+    # Dependencies for productions
+    "mando>=0.6,<0.8",
+    "colorama>=0.4.1; python_version > '3.4'",
+    "colorama==0.4.1; python_version <= '3.4'",
+]
+
+[tool.poetry]
+name = "radon"
+version = "6.0.1"
+description = "Code Metrics in Python"
+authors = ["Michele Lacchia <michelelacchia@gmail.com>"]
+license = "MIT"
+readme = "README.rst"
+
+[tool.poetry.dependencies]
+python = ">=3.7,<4.0"
+mando = ">=0.6,<0.8"
+colorama = [
+    {version = ">=0.4.1", markers = "python_version > \"3.4\""},
+    {version = "==0.4.1", markers = "python_version <= \"3.4\""}
+]
+
+[tool.poetry.group.dev.dependencies]
+coverage = "*"
+coveralls = "*"
+pytest = [
+    {version = ">=2.7", markers = "python_version < \"3.0\""},
+    {version = ">5.0", markers = "python_version >= \"3.0\""}
+]
+pytest-mock = "*"
+argparse = "*"
+nbformat = "*"
+tox = "^4.4.7"
+
+[tool.poetry.scripts]
+radon = "radon:main"
+
+# [build-system]
+# requires = ["poetry-core"]
+# build-backend = "poetry.core.masonry.api"
+
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
## Radon needs standard to approve pull request

We still need Radon that have important roles for maintenancing Python project.
To continue to deploy new versions, Radon need the standard to approve pull request.
Otherwise, any excellent pull requests can't be merged since maintainer can't check those safeness.
This also can be said about `master` branch. After merge this pull request, you'll find that Radon already haven't worked in Pytohn 2.7.

## Summary of this pull request written by Copilot

This pull request introduces a comprehensive overhaul of the project's testing and development environment, focusing on modernizing CI workflows, supporting a broad range of Python versions (including legacy), and improving dependency management. The changes establish robust GitHub Actions workflows, add Docker-based legacy testing, and introduce a new `pyproject-uv.toml` for dependency specification.

**Continuous Integration and Testing Improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/test.yml`) that runs tests across multiple Python versions (3.10–3.14, PyPy 3.10, 3.7, 3.6, and 2.7) using both native and Docker-based strategies, ensuring broad compatibility and reliability.

**Legacy and Docker Support:**

* Introduced `Dockerfile.legacy` to build test environments for legacy Python versions using `pipenv`, and set up a `compose.yml` file to facilitate Docker Compose-based testing for older Python versions. [[1]](diffhunk://#diff-c8a3a6e8d14c848c9c77e9cd6a2c107aec05bb4d51803379f73930935d658130R1-R11) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R1-R11)

**Dependency and Project Configuration:**

* Added `pyproject-uv.toml` to define project dependencies, development tools, and build system configuration, modernizing dependency management and aligning with current Python packaging standards.