### PR TITLE
Fix but that doesn't work in Python 2.7

### DIFF
--- a/radon/cli/__init__.py
+++ b/radon/cli/__init__.py
@@ -82,7 +82,8 @@ class FileConfig(object):
         for path in (os.getenv('RADONCFG', None), 'radon.cfg'):
             if path is not None and os.path.exists(path):
                 config.read_file(open(path))
-        config.read_dict(FileConfig.toml_config())
+        for key, value in FileConfig.toml_config().items():
+            config[key] = value
         config.read(['setup.cfg', os.path.expanduser('~/.radon.cfg')])
         return config
 

--- a/radon/cli/harvest.py
+++ b/radon/cli/harvest.py
@@ -3,7 +3,11 @@
 import collections
 import json
 import sys
-from builtins import super
+
+try:
+    from builtins import super
+except ImportError:
+    from __builtin__ import super
 
 from radon.cli.colors import MI_RANKS, RANKS_COLORS, RESET
 from radon.cli.tools import (


### PR DESCRIPTION
## In Python 2.7, Radon doesn't work

The pytests reported two errors:

```console
radon/cli/harvest.py:6: in <module>
    from builtins import super
E   ImportError: No module named builtins
```

```console
radon/cli/__init__.py:85: in file_config
    config.read_dict(FileConfig.toml_config())
E   AttributeError: ConfigParser instance has no attribute 'read_dict'
```

### Is supporting Python 2 really required instead of sustainability?

We still need Radon that have important roles for maintenancing Python project.

Supporting legacy version holds maintainability back since:

- That prevents to rewrite codes more simple and efficient by new grammer, especially lacking type hinting and out of Ruff supporting Python version range make contributers difficult to maintain
- That requires to maintain development and testing environment by ourselves and almost dependency tools are no longer supplied in official package manager for each Linux distribution

I hope next version will be the last version of supporting legacy Python versions.

## Summary of this pull request written by Copilot

This pull request primarily addresses compatibility and configuration handling improvements in the CLI codebase. The most significant changes include making the import of `super` compatible across Python versions and updating how configuration dictionaries are merged.

**Python compatibility improvements:**
* Updated the import of `super` in `radon/cli/harvest.py` to handle both Python 2 and Python 3 environments, ensuring broader compatibility.

**Configuration handling:**
* Changed the way configuration from `FileConfig.toml_config()` is merged into the main config object in `radon/cli/__init__.py` by assigning each key-value pair directly, improving clarity and possibly preventing issues with `read_dict`.